### PR TITLE
Attempt to fix build by removing unsupported version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: php
 php:
-  - 5.5
-  - 5.4
-  - 5.3
+  - 5.6
+  - 7.0
+  - 7.1
+  - 7.2
 
 before_script:
   - pecl install oauth


### PR DESCRIPTION
For PHP 5.5, I think we need to use the https://docs.travis-ci.com/user/reference/xenial#differences-from-the-trusty-images.

TODO:
- Need to fix dependencies (install phpunit,...)
- Remove install during build
